### PR TITLE
up sdk and intl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.3.0 - 16th May, 2024
+
+* Update dependencies
+* Up intl from ^0.18.0 to ^0.19.0
+* Up SDK to 4.0.0
+
 ## 2.2.0 - 8th Jul, 2023
 
 * Fix SDK dependency

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -133,10 +133,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: a3715e3bc90294e971cb7dc063fbf3cd9ee0ebf8604ffeafabd9e6f16abbdbe6
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.0"
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -402,4 +402,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=3.0.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,14 @@
 name: humanizer
 description: A library to convert Dart values into human-friendly representations.
-version: 2.2.0
+version: 2.3.0
 repository: https://github.com/kentcb/humanizer
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.14.0 <4.0.0'
 
 dependencies:
   decimal: ^2.1.0
-  intl: ^0.18.0
+  intl: ^0.19.0
   meta: ^1.3.0
   rational: ^2.1.0
 


### PR DESCRIPTION
Hello! After upgrade flutter SDK to 3.22 a have problems with my dependencies:
```
Resolving dependencies...
Note: intl is pinned to version 0.19.0 by flutter_localizations from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.

Because humanizer >=2.1.0 depends on intl ^0.18.0 and every version of flutter_localizations from sdk depends on intl 0.19.0, humanizer >=2.1.0 is incompatible with flutter_localizations from sdk.
And because every version of auth_lib depends on flutter_localizations from sdk, humanizer >=2.1.0 is incompatible with auth_lib.
```
In this pr I update intl to 0.19.0. This should solve the problem